### PR TITLE
Add Schneider to glossary

### DIFF
--- a/glossary.json
+++ b/glossary.json
@@ -342,5 +342,13 @@
   "谭天晴": {
     "translation": "Tan Tianqing",
     "note": "Character Name"
+  },
+  "施十四": {
+    "translation": "Shi Shisi",
+    "note": "Original name of Schneider. Former pirate leader."
+  },
+  "施奈德": {
+    "translation": "Schneider",
+    "note": "Navy officer. Formerly Shi Shisi."
   }
 }


### PR DESCRIPTION
Added "Schneider" and "Shi Shisi" to `glossary.json`.

Schneider (施奈德) is a character in the book who is a Navy officer in the Fubo Army.
- Originally named **Shi Shisi** (施十四).
- Former pirate leader under Zhu Kailao.
- Renamed by a Naval Elder.
- Known for his vanity regarding his uniform and medals, and for fabricating a genealogy.


---
*PR created automatically by Jules for task [2716776423672225756](https://jules.google.com/task/2716776423672225756) started by @lpi*